### PR TITLE
feat(ecr): per-rule retention via retentionRules variable

### DIFF
--- a/ecr/main.tf
+++ b/ecr/main.tf
@@ -7,38 +7,64 @@ resource "aws_ecr_repository" "ecr_repository" {
   }
 }
 
-resource "aws_ecr_lifecycle_policy" "ecr_repository" {
-  repository = aws_ecr_repository.ecr_repository.name
+locals {
+  # Purges untagged images; appended last in both policy variants.
+  untagged_rule = {
+    description = "delete all untagged images after 1 day"
+    selection = {
+      tagStatus   = "untagged"
+      countType   = "sinceImagePushed"
+      countUnit   = "days"
+      countNumber = 1
+    }
+    action = { type = "expire" }
+  }
 
-  policy = jsonencode({
-    "rules" : [
+  # Legacy single-rule policy. Used when var.retentionRules is not set, so existing
+  # consumers of this module keep their current behavior unchanged.
+  legacy_policy = jsonencode({
+    rules = [
       {
-        rulePriority : 1,
-        description : "Retain the last 5 images",
-        selection : {
-          "tagStatus" : var.tagStatus,
-          "tagPrefixList" : var.tagPrefixList,
-          "countType" : "imageCountMoreThan",
-          "countNumber" : var.numberImages
-        },
-        action : {
-          "type" : "expire"
+        rulePriority = 1
+        description  = "Retain the last 5 images"
+        selection = {
+          tagStatus     = var.tagStatus
+          tagPrefixList = var.tagPrefixList
+          countType     = "imageCountMoreThan"
+          countNumber   = var.numberImages
         }
+        action = { type = "expire" }
       },
-      {
-        rulePriority : 2,
-        description : "delete all untagged images after 1 day",
-        selection : {
-          "tagStatus" : "untagged",
-          "countType" : "sinceImagePushed",
-          "countUnit" : "days"
-          "countNumber" : 1
-        },
-        action : {
-          "type" : "expire"
-        }
-      }
+      merge(local.untagged_rule, { rulePriority = 2 }),
     ]
+  })
+
+  # One "imageCountMoreThan numberImages" rule per entry in var.retentionRules,
+  # priority following list order, with the untagged-purge rule appended last.
+  retention_rules = var.retentionRules == null ? [] : var.retentionRules
+
+  versioned_policy = jsonencode({
+    rules = concat(
+      [
+        for idx, rule in local.retention_rules : {
+          rulePriority = idx + 1
+          description  = rule.description
+          selection = {
+            tagStatus      = "tagged"
+            tagPatternList = rule.tagPatternList
+            countType      = "imageCountMoreThan"
+            countNumber    = var.numberImages
+          }
+          action = { type = "expire" }
+        }
+      ],
+      [merge(local.untagged_rule, { rulePriority = length(local.retention_rules) + 1 })],
+    )
   })
 }
 
+resource "aws_ecr_lifecycle_policy" "ecr_repository" {
+  repository = aws_ecr_repository.ecr_repository.name
+
+  policy = var.retentionRules == null ? local.legacy_policy : local.versioned_policy
+}

--- a/ecr/variables.tf
+++ b/ecr/variables.tf
@@ -25,3 +25,12 @@ variable "numberImages" {
   default     = 5
   type        = number
 }
+
+variable "retentionRules" {
+  type = list(object({
+    description    = string
+    tagPatternList = list(string)
+  }))
+  description = "Optional. When set, replaces the single tagPrefixList retention rule with one 'imageCountMoreThan numberImages' rule per entry (priority follows list order). When null, the legacy single-rule behavior (tagStatus/tagPrefixList) is used."
+  default     = null
+}


### PR DESCRIPTION
## What

Adds an optional `retentionRules` variable to the `ecr` module.

When set, `aws_ecr_lifecycle_policy` emits **one `imageCountMoreThan numberImages` rule per entry** (priority following list order), followed by the existing untagged-image purge rule.

When **not set**, the module renders the legacy single `tagPrefixList` rule exactly as before — verified byte-identical via `terraform console` — so existing consumers are unaffected.

## Why

Consumers (starting with `gentesty`) need to retain images per major version (e.g. keep the last 5 of `1.x.x` *and* the last 5 of `0.x.x`) plus a catch-all. A single `imageCountMoreThan` rule cannot express this, and `tagPrefixList` entries are AND-combined so they cannot OR two version prefixes.

## Example

```hcl
module "ecr-foo" {
  source       = "github.com/b-nova/infra-modules/ecr"
  name         = "foo"
  team         = "developer"
  numberImages = "5"
  retentionRules = [
    { description = "Retain last 5 of 1.x.x", tagPatternList = ["foo-1.*"] },
    { description = "Retain last 5 of 0.x.x", tagPatternList = ["foo-0.*"] },
    { description = "Retain last 5 of any other tag", tagPatternList = ["*"] },
  ]
}
```

## Verification

- `terraform validate` passes.
- Legacy path (`retentionRules` unset): rendered policy JSON is byte-identical to the previous module output.
- New path: renders N retention rules + the untagged rule with correct priorities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)